### PR TITLE
[#18] Fix db.getUrl() is not a function

### DIFF
--- a/index.js
+++ b/index.js
@@ -72,7 +72,7 @@ module.exports = function httpQuery(db, req) {
     }
 
     //strips the database from the requested_path
-    var url = db.getUrl().split("/").slice(0, -2).join("/") + req.raw_path;
+    var url = db.name.replace(/\/[^\/]+\/?$/, "") + req.raw_path;
     var pouchHeaders = (db.getHeaders || fakeGetHeaders)();
     var headers = extend({}, pouchHeaders, req.headers);
 


### PR DESCRIPTION
In PouchDB 6.x, the db.getUrl() method was deprecated. Instead use
db.name to extract base URL.

Fixes #18.