### PR TITLE
Don't set Header and User-Agent

### DIFF
--- a/index.js
+++ b/index.js
@@ -85,7 +85,9 @@ module.exports = function httpQuery(db, req) {
         if (xhr.setDisableHeaderCheck) {
           xhr.setDisableHeaderCheck(true);
         }
-        xhr.setRequestHeader(name, headers[name]);
+        if (["host", "user-agent"].indexOf(name.toLowerCase()) === -1) {
+          xhr.setRequestHeader(name, headers[name]);
+        }
       }
     }
     xhr.send(req.body === "undefined" ? null : req.body);


### PR DESCRIPTION
Chrome (in Electron) refuses to set the following headers due to security restrictions:

```
Refused to set unsafe header "Host"
Refused to set unsafe header "User-Agent"
```